### PR TITLE
Improved use of set.seed(); Bug fix for group_by/summarise tab

### DIFF
--- a/dataOp/ui.R
+++ b/dataOp/ui.R
@@ -25,7 +25,7 @@ shinyUI(fluidPage(
                column(1),
                
                column(2,
-                      selectInput("tab1", label = strong("Select the 1st table to join"),
+                      selectInput("tab1", label = strong("Select the left table"),
                                   choices = list("Galton", 
                                                  "Dimes", 
                                                  "SwimRecords", 
@@ -44,7 +44,7 @@ shinyUI(fluidPage(
                column(3),
                
                column(2,
-                      selectInput("tab2", label = strong("Select the 2nd table to join"),
+                      selectInput("tab2", label = strong("Select the right table (only used for joins)"),
                                   choices = list("Galton", 
                                                  "Dimes", 
                                                  "SwimRecords",


### PR DESCRIPTION
The current version wasn't displaying the data in the left-most column of the group_by/summarise tab and the data on the join tab didn't match the data on the data selection tab.

These have been fixed.

I also modified the group_by/summarise tab a bit so that it shows the group number (labeled `group #`) and also the grouping variables.

